### PR TITLE
Update README with tested device

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This component does need a dependency on `pywizlight` like @sbidy's component wh
 | Bulb Type | Dimmer | Color Temp | Effects | RGB | Tested? | Example Product |
 |-----------|--------|------------|---------|-----|-----|-----|
 | ESP01_SHDW_01 | X  |   |   |   |  | |
-| ESP01_SHRGB1C_31 | X | X  | X | X |  | |
+| ESP01_SHRGB1C_31 | X | X  | X | X | x | Phillips 555623 recessed |
 | ESP01_SHTW1C_31 | X | X |   |   | X | Phillips 555599 recessed |
 | ESP56_SHTW3_01 | X |  X  | X  |   | X | |
 | ESP01_SHRGB_03 | X | X | X | X | X | |


### PR DESCRIPTION
I have 5 of these bulbs, confirmed they are controllable from HA. Effects, rgb, dimming all works.

Product I bought: https://www.homedepot.com/p/Philips-Color-and-Tunable-White-5-6-in-LED-65W-Equivalent-Dimmable-Smart-Wi-Fi-Wiz-Connected-Recessed-Downlight-Kit-555623/310289033

Confirmation of bulb type:

```
echo '{"method":"getSystemConfig","params":{}}' | nc -u -w 1 <YOU BULB IP> 38899

{
   "method":"getSystemConfig",
   "env":"pro",
   "result":{
      "mac":"<REDACTED>",
      "homeId":<REDACTED>,
      "roomId":<REDACTED>,
      "moduleName":"ESP01_SHRGB1C_31",
      "fwVersion":"1.20.0",
      "groupId":0,
      "drvConf":[
         44,
         1
      ],
      "ewf":[
         255,
         250,
         150,
         255,
         0,
         0,
         40
      ],
      "ewfHex":"fffa96ff000028"
   }
}
```