### PR TITLE
A new service for requesting status update from the device.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,4 @@ switch:
     name: <Name of the device>
     host: <IP of the socket>
 ```
+To request immediate update from the device call the service `light.<Name of the device>_update` or `switch.<Name of the device>_update`. Useful e.g. when the device has been switched on from mains and external system (like DHCP server) is able to trigger status update faster than normal polling cycle would which then could trigger further automations.

--- a/custom_components/wiz_light/__init__.py
+++ b/custom_components/wiz_light/__init__.py
@@ -1,1 +1,119 @@
 """WiZ Light integration."""
+import logging
+import socket
+import threading
+import json
+import time
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_PORT,
+    EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STOP,
+)
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_PORT = 38900
+DOMAIN = "wiz_light"
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+def setup(hass, config):
+    """Set up Wiz Light."""
+    if "wiz_light" in config:
+        conf = config[DOMAIN]
+        port = conf.get(CONF_PORT)
+        listener = WizLightBroadcastListener(hass, port)
+        #hass.data[DOMAIN] = listener
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_START, listener.start_listen)
+        hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, listener.shutdown)
+    return True
+
+
+class WizLightBroadcastListener(threading.Thread):
+    """WizLight broadcast listener."""
+
+    def __init__(self, hass, port):
+        """Initialize."""
+        super().__init__(daemon=True)
+        self._hass = hass
+        self._port = port
+        self._socket = None
+        self._shutdown = False
+        self._firstBeats = {}
+        _LOGGER.debug("Listener initialized")
+
+    def start_listen(self, event):
+        """Start thread."""
+        _LOGGER.debug("Start thread")
+        self.start()
+
+    def shutdown(self, event):
+        """Shutdown thread."""
+        _LOGGER.debug("Shutdown thread")
+        self._shutdown = True
+        self._close_socket()
+
+    def run(self):
+        """Event thread."""
+        self._create_socket()
+        while True:
+            if self._shutdown:
+                break
+            try:
+                datastr, address = self._socket.recvfrom(2048)
+                ip, port = address
+                self._parse_broadcast((datastr.decode('utf-8')).rstrip(), ip)
+            except socket.timeout:
+                continue
+        self._close_socket()
+
+    def _create_socket(self):
+        """Create socket."""
+        if self._socket is None:
+            _LOGGER.debug("Create socket: %i", self._port)
+            self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+            self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+            self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            self._socket.settimeout(10)
+            self._socket.bind(('', self._port))
+
+    def _close_socket(self):
+        """Close socket."""
+        _LOGGER.debug('Close socket')
+        if self._socket is not None:
+            self._socket.close()
+            self._socket = None
+
+    def _parse_broadcast(self, datastr, ip):
+        """Parse incoming broadcase."""
+        _LOGGER.debug("Got broadcast from %s: %s", ip, datastr)
+        try:
+            data = json.loads(datastr)
+        except:
+            _LOGGER.debug("Unparseable broadcast.")
+            return
+        if "method" in data and data["method"] == "firstBeat":
+            now = int(time.time())
+            if (not ip in self._firstBeats) or (now-self._firstBeats[ip] > 180):
+                self._firstBeats[ip] = now
+                _LOGGER.debug("Got firstBeat from %s", ip)
+                time.sleep(1) # Waiting for bulbs to be ready, one second seems to work
+                self._hass.bus.fire("wiz_light_first_beat", {"ip": ip})
+            else:
+                _LOGGER.debug("Got firstBeat from %s but still cooling down from previous one.", ip)
+        else:
+            _LOGGER.debug("Unknown broadcast.")

--- a/custom_components/wiz_light/light.py
+++ b/custom_components/wiz_light/light.py
@@ -53,6 +53,15 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     # Add devices
     async_add_entities([wizbulb])
 
+    # Handle events
+    async def async_handle_event(event):
+        ip = event.data.get("ip")
+        if ip == ip_address:
+            _LOGGER.debug("[wizlight %s] got first beat event", ip_address)
+            await wizbulb.async_update()
+            await wizbulb.async_update_ha_state();
+    hass.bus.async_listen("wiz_light_first_beat", async_handle_event)
+
     # Register services
     async def async_update(call=None):
         """Trigger update."""

--- a/custom_components/wiz_light/switch.py
+++ b/custom_components/wiz_light/switch.py
@@ -34,6 +34,15 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     # Add devices
     async_add_entities([wizplug])
     
+    # Handle events
+    async def async_handle_event(event):
+        ip = event.data.get("ip")
+        if ip == ip_address:
+            _LOGGER.debug("[wizlight %s] got first beat event", ip_address)
+            await wizbulb.async_update()
+            await wizbulb.async_update_ha_state();
+    hass.bus.async_listen("wiz_light_first_beat", async_handle_event)
+
     # Register services
     async def async_update(call=None):
         """Trigger update."""


### PR DESCRIPTION
Please check if my changes would be useful for wider audience. Basically I have defined a service which can be called which then triggers status of the bulb to be queried immediately instead of waiting for normal poll cycle.

My personal use case is that I use real mains switches to turn bulbs on and off instead of smart switches or software. I want to apply some automation (namely flux) when bulb is switched on but now it could take up to one polling cycle (minute?) for HA to pick up the bulb. So I have created UDP broadcast listener which detects firstBeat sent by the bulbs and will then call this new service -> now it takes only few seconds to HA to pick up the lights. I guess one could also call this service from DHCP server instead. Perhaps there are other use cases as well. 

Ideally HA could listen for firstBeats by itself, but not sure if this is feasiable especially since one could use docker and everything...

Ps. Please do sanity check my code should you want to accept this change. I am no python developer and certainly not HA developer. Just started to learn...