### PR TITLE
Don't return an hscolor when bulbs are in color_temp mode

### DIFF
--- a/custom_components/wiz_light/light.py
+++ b/custom_components/wiz_light/light.py
@@ -330,6 +330,7 @@ class WizBulb(LightEntity):
         """Update the temperature."""
         colortemp = self._light.state.get_colortemp()
         if colortemp is None or colortemp == 0:
+            self._temperature = None
             return
         try:
             _LOGGER.debug(
@@ -345,6 +346,10 @@ class WizBulb(LightEntity):
 
     def update_color(self):
         """Update the hs color."""
+        colortemp = self._light.state.get_colortemp()
+        if colortemp is not None and colortemp != 0:
+            self._hscolor = None
+            return
         if self._light.state.get_rgb() is None:
             return
         try:


### PR DESCRIPTION
When HA checks to see what mode bulbs are in, it first checks for a non-None hscolor before looking at temperature. Bulbs which are in color_temp mode should not return an hscolor.

This fixes @rkeet's issue in #80 (though I'm not sure it addresses the original author's problem).