### PR TITLE
Return consistent values from kelvin_*_map

### DIFF
--- a/custom_components/wiz_light/light.py
+++ b/custom_components/wiz_light/light.py
@@ -429,7 +429,7 @@ class WizBulb(LightEntity):
             return kelvin
         except WizLightNotKnownBulb:
             _LOGGER.info("Kelvin is not present in the library. Fallback to 6500")
-            return 6500
+            return color_utils.color_temperature_kelvin_to_mired(6500)
 
     def kelvin_min_map(self):
         """Map the minimum kelvin from YAML."""
@@ -439,5 +439,5 @@ class WizBulb(LightEntity):
                 self._bulbtype.kelvin_range.min
             )
         except WizLightNotKnownBulb:
-            _LOGGER.info("Kelvin is not present in the library. Fallback to 2500")
-            return 2500
+            _LOGGER.info("Kelvin is not present in the library. Fallback to 2200")
+            return color_utils.color_temperature_kelvin_to_mired(2200)


### PR DESCRIPTION
Also makes the default 2200, which is at least the default for my light.

The real problem seems to be that we're getting to this code path too often because the bulbtype is returned as None every time except the first.